### PR TITLE
avoid meta validation issues by never creating a META.yml

### DIFF
--- a/corpus/DZ_CheckChangesHasContent/dist.ini
+++ b/corpus/DZ_CheckChangesHasContent/dist.ini
@@ -6,12 +6,7 @@ abstract = Test Library
 copyright_holder = foobar
 copyright_year   = 2009
 
-[@Filter]
-bundle = @Basic
-remove = ExtraTests
-remove = TestRelease
-remove = ConfirmRelease
-remove = UploadToCPAN
+[GatherDir]
 
 [NextRelease]
 

--- a/corpus/DZ_Test_ChangesHasContent/dist.ini
+++ b/corpus/DZ_Test_ChangesHasContent/dist.ini
@@ -6,12 +6,7 @@ abstract = Test Library
 copyright_holder = foobar
 copyright_year   = 2009
 
-[@Filter]
-bundle = @Basic
-remove = ExtraTests
-remove = TestRelease
-remove = ConfirmRelease
-remove = UploadToCPAN
+[GatherDir]
 
 [NextRelease]
 


### PR DESCRIPTION
When CPAN::Meta and Dist::Zilla versions are out of sync, we can get errors like this:

```
t/test_changeshascontent.t .. 1/? [@Filter/MetaYAML] Invalid META structure.  Errors found:
[@Filter/MetaYAML] Expected a list structure (license) [Validation: 2] at /Volumes/amaretto/Users/ether/.perlbrew/libs/20.0@std/lib/perl5/darwin-2level/Moose/Meta/Method/Delegation.pm line 110.
```

...which aren't your problem. Avoid all this by only pulling in the minimum necessary plugins in tests.
