### PR TITLE
NextRelease 6.005 checks for missing Changes earlier

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Dist-Zilla-Plugin-CheckChangesHasContent
 
 {{$NEXT}}
 
+    [FIXED]
+
+    - fixed tests broken by changes in [NextRelease] 6.005
+
 0.008     2015-03-24 23:31:03-04:00 America/New_York
 
     [FIXED]

--- a/t/checkhascontent.t
+++ b/t/checkhascontent.t
@@ -25,7 +25,7 @@ my $root = 'corpus/DZ_CheckChangesHasContent';
     my $err = $_;
     like(
       $err,
-      qr/No Changes file found/i,
+      qr/No Changes file found|failed to find Changes in the distribution/i,
       "saw missing Changes file warning",
     );
     ok(

--- a/t/test_changeshascontent.t
+++ b/t/test_changeshascontent.t
@@ -28,7 +28,11 @@ sub capture_test_results($)
     return @results, $output;
 }
 
+SKIP:
 {
+    skip '[NextRelease] 6.005 checks for missing Changes file before tests are run', 1
+        if eval { require Dist::Zilla::Plugin::NextRelease; Dist::Zilla::Plugin::NextRelease->VERSION('6.005') };
+
     my $tzil = Dist::Zilla::Tester->from_config(
         { dist_root => $root },
     );


### PR DESCRIPTION
..which broke tests.  In one case we can just check for a different error message, but the other test is not possible to run as the test is never run.

One could inject a sneaky after-build plugin to delete the Changes file, however -- but that requires more extensive rewriting of the tests to alter dist.ini for just one test and not the others.